### PR TITLE
Add function to get scene bounds

### DIFF
--- a/src/scene.rs
+++ b/src/scene.rs
@@ -192,6 +192,28 @@ impl<'a> CommittedScene<'a> {
             );
         }
     }
+    pub fn bounds(&self) -> RTCBounds {
+        #[repr(align(16))]
+        struct Bounds {
+            bounds: RTCBounds,
+        }
+        let mut bounds = Bounds {
+            bounds: RTCBounds {
+                lower_x: 0.0,
+                upper_x: 0.0,
+                lower_y: 0.0,
+                upper_y: 0.0,
+                lower_z: 0.0,
+                upper_z: 0.0,
+                align0: 0.0,
+                align1: 0.0,
+            },
+        };
+        unsafe {
+            rtcGetSceneBounds(self.handle(), &mut bounds.bounds as *mut RTCBounds);
+        }
+        bounds.bounds
+    }
     /// Get the underlying handle to the scene, e.g. for passing it to
     /// native code or ISPC kernels.
     pub unsafe fn handle(&self) -> RTCScene {

--- a/src/scene.rs
+++ b/src/scene.rs
@@ -193,26 +193,20 @@ impl<'a> CommittedScene<'a> {
         }
     }
     pub fn bounds(&self) -> RTCBounds {
-        #[repr(align(16))]
-        struct Bounds {
-            bounds: RTCBounds,
-        }
-        let mut bounds = Bounds {
-            bounds: RTCBounds {
-                lower_x: 0.0,
-                upper_x: 0.0,
-                lower_y: 0.0,
-                upper_y: 0.0,
-                lower_z: 0.0,
-                upper_z: 0.0,
-                align0: 0.0,
-                align1: 0.0,
-            },
+        let mut bounds = RTCBounds {
+            lower_x: 0.0,
+            upper_x: 0.0,
+            lower_y: 0.0,
+            upper_y: 0.0,
+            lower_z: 0.0,
+            upper_z: 0.0,
+            align0: 0.0,
+            align1: 0.0,
         };
         unsafe {
-            rtcGetSceneBounds(self.handle(), &mut bounds.bounds as *mut RTCBounds);
+            rtcGetSceneBounds(self.handle(), &mut bounds as *mut RTCBounds);
         }
-        bounds.bounds
+        bounds
     }
     /// Get the underlying handle to the scene, e.g. for passing it to
     /// native code or ISPC kernels.


### PR DESCRIPTION
Not sure if the wrapping structure is needed, but the docs say that the `RTCBounds` should be 16 byte aligned.