### PR TITLE
Make optional EMBREE_DIR

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -6,11 +6,8 @@ fn main() {
         let mut embree_dir = PathBuf::from(e);
         embree_dir.push("lib");
         println!("cargo:rustc-link-search=native={}", embree_dir.display());
-    } else {
-        println!("cargo:error=Please set EMBREE_DIR=<path to embree3 root>");
-        panic!("Failed to find embree");
+        println!("cargo:rerun-if-env-changed=EMBREE_DIR");
     }
-    println!("cargo:rerun-if-env-changed=EMBREE_DIR");
     println!("cargo:rustc-link-lib=embree3");
 }
 


### PR DESCRIPTION
Hi,

This is a small change to make EMBREE_DIR optional. Indeed, on mainy linux distribution, embree3 will be installed inside /usr which is supported by default by cargo.