### PR TITLE
Implementation of some callbacks

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,3 @@ exclude = [
 	"examples/*"
 ]
 
-[dependencies]
-bitflags = "1.3"
-

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,3 +21,6 @@ exclude = [
 	"examples/*"
 ]
 
+[dependencies]
+bitflags = "1.3"
+

--- a/src/callback.rs
+++ b/src/callback.rs
@@ -1,0 +1,54 @@
+use std::os::raw::c_void;
+
+use crate::sys::*;
+
+/// Helper function to convert a Rust closure to `RTCProgressMonitorFunction` callback.
+pub(crate) fn progress_monitor_function_helper<F>(f: &mut F) -> RTCProgressMonitorFunction
+where
+    F: FnMut(f64) -> bool,
+{
+    unsafe extern "C" fn inner<F>(f: *mut c_void, n: f64) -> bool
+    where
+        F: FnMut(f64) -> bool,
+    {
+        let cb = &mut *(f as *mut F);
+        cb(n)
+    }
+
+    inner::<F>
+}
+
+/// Helper function to convert a Rust closure to `RTCErrorFunction` callback.
+pub(crate) fn error_function_helper<F>(f: &mut F) -> RTCErrorFunction
+where
+    F: FnMut(RTCError, &'static str),
+{
+    unsafe extern "C" fn inner<F>(
+        f: *mut c_void,
+        error: RTCError,
+        msg: *const ::std::os::raw::c_char,
+    ) where
+        F: FnMut(RTCError, &'static str),
+    {
+        let cb = &mut *(f as *mut F);
+        cb(error, std::ffi::CStr::from_ptr(msg).to_str().unwrap())
+    }
+
+    inner::<F>
+}
+
+/// Helper function to convert a Rust closure to `RTCMemoryMonitorFunction` callback.
+pub(crate) fn memory_monitor_function_helper<F>(f: &mut F) -> RTCMemoryMonitorFunction
+where
+    F: FnMut(isize, bool) -> bool,
+{
+    unsafe extern "C" fn inner<F>(f: *mut c_void, bytes: isize, post: bool) -> bool
+    where
+        F: FnMut(isize, bool) -> bool,
+    {
+        let cb = &mut *(f as *mut F);
+        cb(bytes, post)
+    }
+
+    inner::<F>
+}

--- a/src/callback.rs
+++ b/src/callback.rs
@@ -3,7 +3,7 @@ use std::os::raw::c_void;
 use crate::sys::*;
 
 /// Helper function to convert a Rust closure to `RTCProgressMonitorFunction` callback.
-pub(crate) fn progress_monitor_function_helper<F>(f: &mut F) -> RTCProgressMonitorFunction
+pub(crate) fn progress_monitor_function_helper<F>(_f: &mut F) -> RTCProgressMonitorFunction
 where
     F: FnMut(f64) -> bool,
 {
@@ -19,7 +19,7 @@ where
 }
 
 /// Helper function to convert a Rust closure to `RTCErrorFunction` callback.
-pub(crate) fn error_function_helper<F>(f: &mut F) -> RTCErrorFunction
+pub(crate) fn error_function_helper<F>(_f: &mut F) -> RTCErrorFunction
 where
     F: FnMut(RTCError, &'static str),
 {
@@ -38,7 +38,7 @@ where
 }
 
 /// Helper function to convert a Rust closure to `RTCMemoryMonitorFunction` callback.
-pub(crate) fn memory_monitor_function_helper<F>(f: &mut F) -> RTCMemoryMonitorFunction
+pub(crate) fn memory_monitor_function_helper<F>(_f: &mut F) -> RTCMemoryMonitorFunction
 where
     F: FnMut(isize, bool) -> bool,
 {

--- a/src/device.rs
+++ b/src/device.rs
@@ -51,8 +51,8 @@ impl Device {
     ///
     /// # Example
     ///
-    /// ```
-    /// # use embree::Device;
+    /// ```no_run
+    /// use embree::Device;
     /// let device = Device::new();
     /// device.set_error_function(|error, msg| {
     ///    println!("Error: {:?} {}", error, msg);
@@ -109,8 +109,8 @@ impl Device {
     /// deallocation will later free that data block.
     ///
     /// # Example
-    /// ```
-    /// # use embree::Device;
+    /// ```no_run
+    /// use embree::Device;
     /// let device = Device::new();
     /// device.set_memory_monitor_function(|bytes, post| {
     ///     if bytes > 0 {

--- a/src/device.rs
+++ b/src/device.rs
@@ -159,7 +159,6 @@ impl Device {
 
     /// Query the error code of the device.
     ///
-    ///
     /// Each thread has its own error code per device. If an error occurs when calling
     /// an API function, this error code is set to the occurred error if it stores no
     /// previous error. The `error_code` function reads and returns the currently stored

--- a/src/device.rs
+++ b/src/device.rs
@@ -143,6 +143,35 @@ impl Device {
             rtcSetDeviceMemoryMonitorFunction(self.handle, None, ptr::null_mut());
         }
     }
+
+    /// Query properties of the device.
+    ///
+    /// # Arguments
+    ///
+    /// * `prop` - The property to query. See `RTCDeviceProp` for possible values.
+    ///
+    /// # Returns
+    ///
+    /// An integer of type `isize`.
+    pub fn query_property(&self, prop: RTCDeviceProperty) -> isize {
+        unsafe { rtcGetDeviceProperty(self.handle, prop) }
+    }
+
+    /// Query the error code of the device.
+    ///
+    ///
+    /// Each thread has its own error code per device. If an error occurs when calling
+    /// an API function, this error code is set to the occurred error if it stores no
+    /// previous error. The `error_code` function reads and returns the currently stored
+    /// error and clears the error code. This assures that the returned error code is
+    /// always the first error occurred since the last invocation of `error_code`.
+    ///
+    /// # Returns
+    ///
+    /// Error code encoded as `RTCError`.
+    pub fn error_code(&self) -> RTCError {
+        unsafe { rtcGetDeviceError(self.handle) }
+    }
 }
 
 impl Drop for Device {

--- a/src/geometry.rs
+++ b/src/geometry.rs
@@ -1,3 +1,4 @@
+use crate::callback;
 use crate::sys::*;
 
 /// Geometry trait implemented by all Embree Geometry types
@@ -6,6 +7,56 @@ pub trait Geometry {
     fn commit(&mut self) {
         unsafe {
             rtcCommitGeometry(self.handle());
+        }
+    }
+
+    /// Set the subdivision mode for the topology of the specified subdivision
+    /// geometry.
+    ///
+    /// The subdivision modes can be used to force linear interpolation for certain
+    /// parts of the subdivision mesh:
+    ///
+    /// * [`RTCSubdivisionMode::NO_BOUNDARY`]: Boundary patches are ignored.
+    /// This way each rendered patch has a full set of control vertices.
+    ///
+    /// * [`RTCSubdivisionMode::SMOOTH_BOUNDARY`]: The sequence of boundary
+    /// control points are used to generate a smooth B-spline boundary curve
+    /// (default mode).
+    ///
+    /// * [`RTCSubdivisionMode::PIN_CORNERS`]: Corner vertices are pinned to
+    /// their location during subdivision.
+    ///
+    /// * [`RTCSubdivisionMode::PIN_BOUNDARY`]: All vertices at the border are
+    /// pinned to their location during subdivision. This way the boundary is
+    /// interpolated linearly. This mode is typically used for texturing to also map
+    /// texels at the border of the texture to the mesh.
+    ///
+    /// * [`RTCSubdivisionMode::PIN_ALL`]: All vertices at the border are pinned
+    /// to their location during subdivision. This way all patches are linearly
+    /// interpolated.
+    fn set_subdivision_mode(&self, topology_id: u32, mode: RTCSubdivisionMode) {
+        unsafe {
+            rtcSetGeometrySubdivisionMode(self.handle(), topology_id, mode);
+        }
+    }
+
+    /// Binds a vertex attribute to a topology of the geometry.
+    ///
+    /// This function binds a vertex attribute buffer slot to a topology for the
+    /// specified subdivision geometry. Standard vertex buffers are always bound to
+    /// the default topology (topology 0) and cannot be bound differently. A vertex
+    /// attribute buffer always uses the topology it is bound to when used in the
+    /// `rtcInterpolate` and `rtcInterpolateN` calls.
+    ///
+    /// A topology with ID `i` consists of a subdivision mode set through
+    /// `Geometry::set_subdivision_mode` and the index buffer bound to the index
+    /// buffer slot `i`. This index buffer can assign indices for each face of the
+    /// subdivision geometry that are different to the indices of the default topology.
+    /// These new indices can for example be used to introduce additional borders into
+    /// the subdivision mesh to map multiple textures onto one subdivision geometry.
+    fn set_vertex_attribute_topology(&self, vertex_attribute_id: u32, topology_id: u32) {
+        unsafe {
+            rtcSetGeometryVertexAttributeTopology(self.handle(), vertex_attribute_id, topology_id);
         }
     }
 }

--- a/src/intersect_context.rs
+++ b/src/intersect_context.rs
@@ -48,13 +48,4 @@ impl IntersectContext {
             instID: [u32::MAX; 1],
         }
     }
-
-    /// Initialize the context to default values.
-    ///
-    /// This function should be called to initialize every intersection context.
-    pub fn init(&mut self) {
-        unsafe {
-            rtcInitIntersectContext(self as *mut _);
-        }
-    }
 }

--- a/src/intersect_context.rs
+++ b/src/intersect_context.rs
@@ -1,0 +1,60 @@
+use crate::sys::*;
+
+/// Per ray-query intersection context.
+///
+/// This is used to configure intersection flags, specify a filter callback function,
+/// and specify the chain of IDs of the current instance, and to attach arbitrary user
+/// data to the query (e.g. per ray data).
+///
+/// # Filter Callback
+///
+/// A filter function can be specified inside the context. This function is invoked as
+/// a second filter stage after the per-geometry intersect or occluded filter function
+/// is invoked. Only rays that passed the first filter stage are valid in this second
+/// filter stage. Having such a per ray-query filter function can be useful
+/// to implement modifications of the behavior of the query, such as collecting all
+/// hits or accumulating transparencies.
+///
+/// ## Note
+///
+/// The support for the context filter function must be enabled for a scene by using
+/// the [`RTCSceneFlags::CONTEXT_FILTER_FUNCTION`] flag.
+///
+/// In case of instancing this feature has to get enabled also for each instantiated scene.
+///
+/// # Hints
+///
+/// Best primary ray performance can be obtained by using the ray stream API
+/// and setting the intersect context flag to [`RTCIntersectContextFlags::COHERENT`].
+/// For secondary rays, it is typically better to use the [`RTCIntersectContextFlags::INCOHERENT`],
+/// unless the rays are known to be coherent(e.g. for primary transparency rays).
+pub type IntersectContext = RTCIntersectContext;
+
+impl IntersectContext {
+    /// Shortcut to create a IntersectContext with coherent flag set.
+    pub fn coherent() -> IntersectContext {
+        IntersectContext::new(RTCIntersectContextFlags::COHERENT)
+    }
+
+    /// Shortcut to create a IntersectContext with incoherent flag set.
+    pub fn incoherent() -> IntersectContext {
+        IntersectContext::new(RTCIntersectContextFlags::INCOHERENT)
+    }
+
+    pub fn new(flags: RTCIntersectContextFlags) -> IntersectContext {
+        RTCIntersectContext {
+            flags,
+            filter: None,
+            instID: [u32::MAX; 1],
+        }
+    }
+
+    /// Initialize the context to default values.
+    ///
+    /// This function should be called to initialize every intersection context.
+    pub fn init(&mut self) {
+        unsafe {
+            rtcInitIntersectContext(self as *mut _);
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,6 +34,7 @@ pub mod soa_ray;
 #[allow(non_snake_case)]
 pub mod sys;
 pub mod triangle_mesh;
+mod callback;
 
 pub use bezier_curve::BezierCurve;
 pub use bspline_curve::BsplineCurve;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -49,7 +49,7 @@ pub use quad_mesh::QuadMesh;
 pub use ray::{Hit, IntersectContext, Ray, RayHit};
 pub use ray_packet::{Hit4, Ray4, RayHit4};
 pub use ray_stream::{HitN, RayHitN, RayN};
-pub use scene::Scene;
+pub use scene::{Scene, SceneFlags};
 pub use soa_ray::{
     SoAHit, SoAHitIter, SoAHitIterMut, SoAHitRef, SoARay, SoARayIter, SoARayIterMut, SoARayRef,
     SoARayRefMut,
@@ -69,7 +69,6 @@ pub use sys::RTCSubdivisionMode as SubdivisionMode;
 pub use sys::RTCBuildFlags as BuildFlags;
 pub use sys::RTCCurveFlags as CurveFlags;
 pub use sys::RTCIntersectContextFlags as IntersectContextFlags;
-pub use sys::RTCSceneFlags as SceneFlags;
 
 /// Utility for making specifically aligned vectors
 pub fn aligned_vector<T>(len: usize, align: usize) -> Vec<T> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,6 +23,7 @@ pub mod device;
 pub mod geometry;
 pub mod hermite_curve;
 pub mod instance;
+pub mod intersect_context;
 pub mod linear_curve;
 pub mod quad_mesh;
 pub mod ray;
@@ -45,12 +46,13 @@ pub use device::{Config, Device, FrequencyLevel, Isa};
 pub use geometry::Geometry;
 pub use hermite_curve::HermiteCurve;
 pub use instance::Instance;
+pub use intersect_context::IntersectContext;
 pub use linear_curve::LinearCurve;
 pub use quad_mesh::QuadMesh;
-pub use ray::{Hit, IntersectContext, Ray, RayHit};
+pub use ray::{Hit, Ray, RayHit};
 pub use ray_packet::{Hit4, Ray4, RayHit4};
 pub use ray_stream::{HitN, RayHitN, RayN};
-pub use scene::{Scene, SceneFlags};
+pub use scene::Scene;
 pub use soa_ray::{
     SoAHit, SoAHitIter, SoAHitIterMut, SoAHitRef, SoARay, SoARayIter, SoARayIterMut, SoARayRef,
     SoARayRefMut,
@@ -70,6 +72,7 @@ pub use sys::RTCSubdivisionMode as SubdivisionMode;
 pub use sys::RTCBuildFlags as BuildFlags;
 pub use sys::RTCCurveFlags as CurveFlags;
 pub use sys::RTCIntersectContextFlags as IntersectContextFlags;
+pub use sys::RTCSceneFlags as SceneFlags;
 
 /// Utility for making specifically aligned vectors
 pub fn aligned_vector<T>(len: usize, align: usize) -> Vec<T> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,6 +16,7 @@ use std::{alloc, mem};
 pub mod bezier_curve;
 pub mod bspline_curve;
 pub mod buffer;
+mod callback;
 pub mod catmull_rom_curve;
 pub mod curve;
 pub mod device;
@@ -34,7 +35,6 @@ pub mod soa_ray;
 #[allow(non_snake_case)]
 pub mod sys;
 pub mod triangle_mesh;
-mod callback;
 
 pub use bezier_curve::BezierCurve;
 pub use bspline_curve::BsplineCurve;

--- a/src/ray.rs
+++ b/src/ray.rs
@@ -5,7 +5,6 @@ use crate::sys;
 pub type Ray = sys::RTCRay;
 pub type Hit = sys::RTCHit;
 pub type RayHit = sys::RTCRayHit;
-pub type IntersectContext = sys::RTCIntersectContext;
 
 impl Ray {
     /// Create a new ray starting at `origin` and heading in direction `dir`
@@ -51,24 +50,8 @@ impl Hit {
 impl RayHit {
     pub fn new(ray: Ray) -> RayHit {
         sys::RTCRayHit {
-            ray: ray,
+            ray,
             hit: Hit::new(),
-        }
-    }
-}
-
-impl IntersectContext {
-    pub fn coherent() -> IntersectContext {
-        IntersectContext::new(sys::RTCIntersectContextFlags::COHERENT)
-    }
-    pub fn incoherent() -> IntersectContext {
-        IntersectContext::new(sys::RTCIntersectContextFlags::INCOHERENT)
-    }
-    fn new(flags: sys::RTCIntersectContextFlags) -> IntersectContext {
-        sys::RTCIntersectContext {
-            flags: flags,
-            filter: None,
-            instID: [u32::MAX; 1],
         }
     }
 }

--- a/src/scene.rs
+++ b/src/scene.rs
@@ -76,8 +76,8 @@ impl Scene {
     ///
     /// Useful when setting individual flags, e.g. to just set the robust mode without
     /// changing other flags the following way:
-    /// ```
-    /// # use embree::{Device, Scene, SceneFlags};
+    /// ```no_run
+    /// use embree::{Device, Scene, SceneFlags};
     /// let device = Device::new();
     /// let scene = Scene::new(device.clone());
     /// let flags = scene.flags();

--- a/src/scene.rs
+++ b/src/scene.rs
@@ -111,8 +111,13 @@ impl Scene {
     /// scene.set_flags(flags | SceneFlags::ROBUST);
     /// ```
     pub fn flags(&self) -> SceneFlags {
+        unsafe { rtcGetSceneFlags(self.handle).into() }
+    }
+
+    /// Set the build quatity of the scene. See [`RTCBuildQuality`] for all possible values.
+    pub fn set_build_quality(&self, quality: RTCBuildQuality) {
         unsafe {
-            rtcGetSceneFlags(self.handle).into()
+            rtcSetSceneBuildQuality(self.handle, quality);
         }
     }
 

--- a/src/scene.rs
+++ b/src/scene.rs
@@ -77,7 +77,9 @@ impl Scene {
     /// Useful when setting individual flags, e.g. to just set the robust mode without
     /// changing other flags the following way:
     /// ```
-    /// # use embree::SceneFlags;
+    /// # use embree::{Device, Scene, SceneFlags};
+    /// let device = Device::new();
+    /// let scene = Scene::new(device.clone());
     /// let flags = scene.flags();
     /// scene.set_flags(flags | SceneFlags::ROBUST);
     /// ```

--- a/src/sys.rs
+++ b/src/sys.rs
@@ -374,9 +374,6 @@ pub struct RTCIntersectContext {
     pub filter: RTCFilterFunctionN,
     pub instID: [::std::os::raw::c_uint; 1usize],
 }
-extern "C" {
-    pub fn rtcInitIntersectContext(context: *mut RTCIntersectContext);
-}
 #[test]
 fn bindgen_test_layout_RTCIntersectContext() {
     assert_eq!(

--- a/src/sys.rs
+++ b/src/sys.rs
@@ -374,6 +374,9 @@ pub struct RTCIntersectContext {
     pub filter: RTCFilterFunctionN,
     pub instID: [::std::os::raw::c_uint; 1usize],
 }
+extern "C" {
+    pub fn rtcInitIntersectContext(context: *mut RTCIntersectContext);
+}
 #[test]
 fn bindgen_test_layout_RTCIntersectContext() {
     assert_eq!(

--- a/src/sys.rs
+++ b/src/sys.rs
@@ -939,27 +939,24 @@ pub enum RTCError {
 extern "C" {
     pub fn rtcGetDeviceError(device: RTCDevice) -> RTCError;
 }
-pub type RTCErrorFunction = ::std::option::Option<
-    unsafe extern "C" fn(
-        userPtr: *mut ::std::os::raw::c_void,
-        code: RTCError,
-        str_: *const ::std::os::raw::c_char,
-    ),
->;
+pub type RTCErrorFunction = unsafe extern "C" fn(
+    userPtr: *mut ::std::os::raw::c_void,
+    code: RTCError,
+    str_: *const ::std::os::raw::c_char,
+);
 extern "C" {
     pub fn rtcSetDeviceErrorFunction(
         device: RTCDevice,
-        error: RTCErrorFunction,
+        error: Option<RTCErrorFunction>,
         userPtr: *mut ::std::os::raw::c_void,
     );
 }
-pub type RTCMemoryMonitorFunction = ::std::option::Option<
-    unsafe extern "C" fn(ptr: *mut ::std::os::raw::c_void, bytes: ssize_t, post: bool) -> bool,
->;
+pub type RTCMemoryMonitorFunction =
+    unsafe extern "C" fn(ptr: *mut ::std::os::raw::c_void, bytes: ssize_t, post: bool) -> bool;
 extern "C" {
     pub fn rtcSetDeviceMemoryMonitorFunction(
         device: RTCDevice,
-        memoryMonitor: RTCMemoryMonitorFunction,
+        memoryMonitor: Option<RTCMemoryMonitorFunction>,
         userPtr: *mut ::std::os::raw::c_void,
     );
 }
@@ -4026,11 +4023,11 @@ extern "C" {
     pub fn rtcJoinCommitScene(scene: RTCScene);
 }
 pub type RTCProgressMonitorFunction =
-    ::std::option::Option<unsafe extern "C" fn(ptr: *mut ::std::os::raw::c_void, n: f64) -> bool>;
+    unsafe extern "C" fn(ptr: *mut ::std::os::raw::c_void, n: f64) -> bool;
 extern "C" {
     pub fn rtcSetSceneProgressMonitorFunction(
         scene: RTCScene,
-        progress: RTCProgressMonitorFunction,
+        progress: Option<RTCProgressMonitorFunction>,
         ptr: *mut ::std::os::raw::c_void,
     );
 }


### PR DESCRIPTION
Hi @Twinklebear ,

I added some documentation and implemented following methods.

- [X] device error callback
- [X] device memory monitor callback
- [x] device error code getter
- [X] device property getter
- [X] scene progress monitor callback
- [X] scene flags setter/getter
- [X] scene build quality setter
- [X] geometry subdivision mode setter
- [X] geometry vertex attribute topology setter

Intersection related callbacks are a little bit tricky to implement, still need to some time to do it.