### PR TITLE
cgmath version 0.18 and automatic arcball camera placement

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,5 +21,5 @@ exclude = [
 ]
 
 [dependencies]
-cgmath = "0.17.0"
+cgmath = "0.18"
 

--- a/examples/curve_geometry/Cargo.toml
+++ b/examples/curve_geometry/Cargo.toml
@@ -6,5 +6,5 @@ authors = ["Will Usher <willusher.life@gmail.com>"]
 [dependencies]
 embree = { path = "../../" }
 support = { path = "../support" }
-cgmath = "0.17.0"
+cgmath = "0.18.0"
 

--- a/examples/instancing/Cargo.toml
+++ b/examples/instancing/Cargo.toml
@@ -6,5 +6,5 @@ authors = ["Will Usher <willusher.life@gmail.com>"]
 [dependencies]
 embree = { path = "../../" }
 support = { path = "../support" }
-cgmath = "0.17.0"
+cgmath = "0.18.0"
 

--- a/examples/obj_ao_parallel/Cargo.toml
+++ b/examples/obj_ao_parallel/Cargo.toml
@@ -6,7 +6,7 @@ authors = ["Will Usher <willusher.life@gmail.com>"]
 [dependencies]
 embree = { path = "../../" }
 support = { path = "../support" }
-cgmath = "0.17.0"
+cgmath = "0.18.0"
 tobj = "0.1.6"
 rayon = "1.3"
 rand = "0.7"

--- a/examples/obj_viewer/Cargo.toml
+++ b/examples/obj_viewer/Cargo.toml
@@ -6,6 +6,6 @@ authors = ["Will Usher <willusher.life@gmail.com>"]
 [dependencies]
 embree = { path = "../../" }
 support = { path = "../support" }
-cgmath = "0.17.0"
+cgmath = "0.18.0"
 tobj = "0.1.6"
 

--- a/examples/support/Cargo.toml
+++ b/examples/support/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Will Usher <willusher.life@gmail.com>"]
 
 [dependencies]
 image = "0.22.0"
-arcball = {path = "../../../arcball" }
+arcball = "1.1.0"
 cgmath = "0.18.0"
 clock_ticks = "0.1.1"
 

--- a/examples/support/Cargo.toml
+++ b/examples/support/Cargo.toml
@@ -5,8 +5,8 @@ authors = ["Will Usher <willusher.life@gmail.com>"]
 
 [dependencies]
 image = "0.22.0"
-arcball = "1.0.0"
-cgmath = "0.17.0"
+arcball = {path = "../../../arcball" }
+cgmath = "0.18.0"
 clock_ticks = "0.1.1"
 
 [dependencies.glium]

--- a/examples/support/src/aabb.rs
+++ b/examples/support/src/aabb.rs
@@ -1,0 +1,50 @@
+use cgmath::InnerSpace;
+use std::f32;
+use vec_max;
+use vec_min;
+use Vector3;
+
+#[derive(Clone, Debug)]
+pub struct AABB {
+    pub p_min: Vector3,
+    pub p_max: Vector3,
+}
+
+impl Default for AABB {
+    fn default() -> Self {
+        Self {
+            p_min: Vector3::new(std::f32::MAX, std::f32::MAX, std::f32::MAX),
+            p_max: Vector3::new(std::f32::MIN, std::f32::MIN, std::f32::MIN),
+        }
+    }
+}
+
+impl AABB {
+    pub fn is_valid(&self) -> bool {
+        self.p_max.x >= self.p_min.x && self.p_max.y >= self.p_min.y && self.p_max.z >= self.p_min.z
+    }
+
+    pub fn union_aabb(&self, b: &AABB) -> AABB {
+        AABB {
+            p_min: vec_min(&self.p_min, &b.p_min),
+            p_max: vec_max(&self.p_max, &b.p_max),
+        }
+    }
+
+    pub fn union_vec(&self, v: &Vector3) -> AABB {
+        AABB {
+            p_min: vec_min(&self.p_min, v),
+            p_max: vec_max(&self.p_max, v),
+        }
+    }
+
+    #[inline]
+    pub fn size(&self) -> Vector3 {
+        self.p_max - self.p_min
+    }
+
+    #[inline]
+    pub fn center(&self) -> Vector3 {
+        self.size() * 0.5 + self.p_min
+    }
+}

--- a/examples/support/src/lib.rs
+++ b/examples/support/src/lib.rs
@@ -11,9 +11,11 @@ type Vector2 = cgmath::Vector2<f32>;
 type Vector3 = cgmath::Vector3<f32>;
 type Vector4 = cgmath::Vector4<f32>;
 
+pub mod aabb;
 pub mod camera;
 pub mod display;
 
+pub use aabb::AABB;
 pub use camera::Camera;
 pub use display::Display;
 
@@ -26,4 +28,12 @@ pub fn clamp<T: PartialOrd>(x: T, min: T, max: T) -> T {
     } else {
         x
     }
+}
+
+fn vec_min(v1: &Vector3, v2: &Vector3) -> Vector3 {
+    Vector3::new(v1.x.min(v2.x), v1.y.min(v2.y), v1.z.min(v2.z))
+}
+
+fn vec_max(v1: &Vector3, v2: &Vector3) -> Vector3 {
+    Vector3::new(v1.x.max(v2.x), v1.y.max(v2.y), v1.z.max(v2.z))
 }

--- a/examples/triangle/Cargo.toml
+++ b/examples/triangle/Cargo.toml
@@ -6,5 +6,5 @@ authors = ["Will Usher <willusher.life@gmail.com>"]
 [dependencies]
 embree = { path = "../../" }
 support = { path = "../support" }
-cgmath = "0.17.0"
+cgmath = "0.18.0"
 

--- a/examples/triangle_geometry/Cargo.toml
+++ b/examples/triangle_geometry/Cargo.toml
@@ -6,5 +6,5 @@ authors = ["Will Usher <willusher.life@gmail.com>"]
 [dependencies]
 embree = { path = "../../" }
 support = { path = "../support" }
-cgmath = "0.17.0"
+cgmath = "0.18.0"
 


### PR DESCRIPTION
Hi Will, 

Please find a pull request that implements two changes:
1) Bump cgmath to last version (0.18). 
2) Compute AABB from the loaded obj to automatically place the camera for obj_viewer and obj_ao_parallel. This changes the support `display` struct and adds a new `aabb` struct.

Best

